### PR TITLE
Fix ThemeToggle stylesheet detection

### DIFF
--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -8,7 +8,7 @@ export const ThemeToggle = () => {
   // Initialise theme from localStorage or system preference
   useEffect(() => {
     const stored = localStorage.getItem('theme');
-    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 
     if (stored === 'dark' || (!stored && systemPrefersDark)) {
       document.documentElement.classList.add('dark');


### PR DESCRIPTION
## Summary
- remove non-breaking space in ThemeToggle's media query

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686051760a348325b280fefd2b503871