### PR TITLE
Add day sky background and update star style

### DIFF
--- a/src/components/DayBackground.jsx
+++ b/src/components/DayBackground.jsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+const CLOUD_COUNT = 5;
+
+export const DayBackground = () => {
+  const [clouds, setClouds] = useState([]);
+
+  useEffect(() => {
+    const generateClouds = () => {
+      const next = Array.from({ length: CLOUD_COUNT }, (_, i) => ({
+        id: `cloud-${i}`,
+        size: Math.random() * 40 + 60,
+        x: Math.random() * 100,
+        y: Math.random() * 30 + 10,
+        delay: Math.random() * 3,
+        duration: Math.random() * 20 + 20,
+      }));
+      setClouds(next);
+    };
+
+    generateClouds();
+    window.addEventListener('resize', generateClouds);
+    return () => window.removeEventListener('resize', generateClouds);
+  }, []);
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-0 overflow-hidden day-bg dark:hidden">
+      <div className="sun" />
+      {clouds.map((c) => (
+        <div
+          key={c.id}
+          className="cloud animate-cloud"
+          style={{
+            width: `${c.size}px`,
+            height: `${c.size / 2}px`,
+            left: `${c.x}%`,
+            top: `${c.y}%`,
+            animationDelay: `${c.delay}s`,
+            animationDuration: `${c.duration}s`,
+          }}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/components/StarBackground.jsx
+++ b/src/components/StarBackground.jsx
@@ -11,7 +11,7 @@ export const StarBackground = () => {
     const count = Math.floor((window.innerWidth * window.innerHeight) / STAR_DENSITY);
     const next = Array.from({ length: count }, (_, i) => ({
       id: `star-${i}`,
-      size: Math.random() * 3 + 1,
+      size: Math.random() * 4 + 2,
       x: Math.random() * 100,
       y: Math.random() * 100,
       opacity: Math.random() * 0.5 + 0.5,
@@ -44,7 +44,7 @@ export const StarBackground = () => {
   }, [generateStars, generateMeteors]);
 
   return (
-    <div className="pointer-events-none fixed inset-0 z-0 overflow-hidden">
+    <div className="pointer-events-none fixed inset-0 z-0 overflow-hidden hidden dark:block">
       {stars.map((s) => (
         <div
           key={s.id}

--- a/src/index.css
+++ b/src/index.css
@@ -147,13 +147,47 @@
 }
 
 @utility star {
-  @apply absolute rounded-full bg-white;
-  box-shadow: 0 0 10px 2px rgba(255, 255, 255, 0.4);
+  @apply absolute bg-yellow-200;
+  clip-path: polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%);
+  box-shadow: 0 0 10px 2px rgba(255, 255, 255, 0.5);
 }
 
 @utility meteor {
   @apply absolute bg-gradient-to-r from-white via-white to-transparent rounded-full;
   box-shadow: 0 0 10px 5px rgba(255, 255, 255, 0.3);
+}
+
+@utility day-bg {
+  @apply bg-gradient-to-b from-sky-200 to-sky-50;
+}
+
+@utility sun {
+  @apply absolute bg-yellow-300 rounded-full;
+  width: 150px;
+  height: 150px;
+  top: 10%;
+  right: 10%;
+  box-shadow: 0 0 50px rgba(253, 224, 71, 0.6);
+}
+
+@utility cloud {
+  @apply absolute bg-white/80 rounded-full;
+  box-shadow: 0 0 20px rgba(255, 255, 255, 0.3);
+}
+
+@keyframes cloud {
+  from {
+    transform: translateX(-200px);
+  }
+  to {
+    transform: translateX(calc(100vw + 200px));
+  }
+}
+
+@utility animate-cloud {
+  animation-name: cloud;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
 }
 
 #root {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,6 @@
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { StarBackground } from '@/components/StarBackground';
+import { DayBackground } from '@/components/DayBackground';
 import { Navbar } from '@/components/Navbar';
 import { HomeSection } from '@/components/HomeSection';
 import { AboutSection } from '@/components/AboutSection';
@@ -8,6 +9,7 @@ export const Home = () => (
   <div className="min-h-screen overflow-x-hidden bg-background text-foreground">
     <ThemeToggle />
     <StarBackground />
+    <DayBackground />
     <Navbar />
 
     <main>


### PR DESCRIPTION
## Summary
- create DayBackground component with sun and clouds
- show star background only in dark mode and improve star size
- update star styles for yellow star shape and animate clouds
- add gradient day sky utilities

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686052a63c3083259a24f200bfb51007